### PR TITLE
Fix wrangler file formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,9 @@ jobs:
       run: |
         npm install -g @cloudflare/wrangler
         wrangler init --site flotiq-blog
-        sed -i 's+account_id = ""+account_id = '"'"$ACCOUNT_ID"'"'+g' wrangler.toml
+        sed -i 's+account_id = '\'\''+account_id = '"'"$ACCOUNT_ID"'"'+g' wrangler.toml
         sed -i 's+bucket = ""+bucket = "public"+g' wrangler.toml
-        sed -i 's+zone_id = ""+zone_id = '"'"$ZONE_ID"'"'+g' wrangler.toml
+        sed -i 's+zone_id = '\'\''+zone_id = '"'"$ZONE_ID"'"'+g' wrangler.toml
         sed -i 's+workers_dev = true++g' wrangler.toml
         echo "[env.production]" >> wrangler.toml
         echo "route = 'flotiq.com/blog/*'" >> wrangler.toml        


### PR DESCRIPTION
Fix for build errors.

Comparing auto generated (by wrangler init)  fileswrangler.toml for different versions:

Wrangler v 1.16.0 - not working
```
cat wrangler.toml
name = "michal"
type = 'webpack'
account_id = ''
route = ''
zone_id = ''
usage_model = ''
workers_dev = true
target_type = "webpack"
site = {bucket = "",entry-point = "workers-site"}
```
Wrangler 1.13.0 - working:
```
name = "michal"
type = "webpack"
account_id = ""
workers_dev = true
route = ""
zone_id = ""

[site]
bucket = ""
entry-point = "workers-site"
```
(notice single and double quote marks)