### PR TITLE
Add default size for content column #22733

### DIFF
--- a/src/templates/post.js
+++ b/src/templates/post.js
@@ -168,7 +168,7 @@ const PostPage = ({ data, pageContext }) => {
                                 <SharePostButtons />
                             </div>
                         </Col>
-                        <Col>
+                        <Col lg={10} md={10} sm={0} xs={0}>
                             <Content
                                 blocks={post.content.blocks}
                                 quoteProps={{ variant: 'light' }}


### PR DESCRIPTION
Original issue - the code block was pushing the column 
Solution - use specified width for content column

Before 

![image](https://user-images.githubusercontent.com/645716/234031899-93661757-6e09-4385-a15a-13bacc3881fb.png)

After
![image](https://user-images.githubusercontent.com/645716/234032052-fb08572d-6dc3-4cbf-be82-a6344eb42098.png)
