### PR TITLE
#25780 Move blog to flotiq.com/blog

### DIFF
--- a/.flotiq/ContentType3/contentObject01.json
+++ b/.flotiq/ContentType3/contentObject01.json
@@ -73,7 +73,7 @@
       {
         "id": "fUC1RIrQY5",
         "data": {
-          "text": "<a href=\"https://blog.flotiq.com/content-management-systems\" target=\"_blank\">Read more about different kinds of CMS systems.</a>"
+          "text": "<a href=\"https://flotiq.com/blog/content-management-systems\" target=\"_blank\">Read more about different kinds of CMS systems.</a>"
         },
         "type": "paragraph",
         "tunes": {

--- a/.flotiq/ContentType3/contentObject02.json
+++ b/.flotiq/ContentType3/contentObject02.json
@@ -59,7 +59,7 @@
       {
         "id": "tLJomB1RnM",
         "data": {
-          "text": "A good CMS helps you manage elements necessary for SEO, i.e. the web site's performance, HTML structure, updates to the Google index. Click <a href=\"https://blog.flotiq.com/content-management-systems\">here</a> to read about a different kind of Content Management Systems."
+          "text": "A good CMS helps you manage elements necessary for SEO, i.e. the web site's performance, HTML structure, updates to the Google index. Click <a href=\"https://flotiq.com/blog/content-management-systems\">here</a> to read about a different kind of Content Management Systems."
         },
         "type": "paragraph",
         "tunes": {
@@ -161,7 +161,7 @@
       {
         "id": "Y39iGXHQ57",
         "data": {
-          "text": "Think of Wikipedia articles - the same page layout but different text and images inside. An identical visual style across the website is something your readers will look for. At this point, you will look at a more sophisticated tool than a simple landing page builder. You will either host your website on a shared hosting platform, e.g. <a href=\"http://wordpress.com/\">Wordpress.com</a> or host it on your own. Go <a href=\"https://blog.flotiq.com/wordpress-alternatives\">here</a> to look at the Wordpress alternatives.&nbsp;"
+          "text": "Think of Wikipedia articles - the same page layout but different text and images inside. An identical visual style across the website is something your readers will look for. At this point, you will look at a more sophisticated tool than a simple landing page builder. You will either host your website on a shared hosting platform, e.g. <a href=\"http://wordpress.com/\">Wordpress.com</a> or host it on your own. Go <a href=\"https://flotiq.com/blog/wordpress-alternatives\">here</a> to look at the Wordpress alternatives.&nbsp;"
         },
         "type": "paragraph",
         "tunes": {

--- a/.flotiq/ContentType6/contentObject01.json
+++ b/.flotiq/ContentType6/contentObject01.json
@@ -25,7 +25,7 @@
   ],
   "footer_2_column": [
     {
-      "url": "https://blog.flotiq.com/",
+      "url": "https://flotiq.com/blog",
       "text": "Blog"
     },
     {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       run: |
         npm install -g gatsby-cli@5.13.2
         gatsby clean
-        gatsby build
+        gatsby build --prefix-paths
 #        rm -rf public/blog
 #        mkdir -p public/blog
 #        find public/ -maxdepth 1 -mindepth 1 -not -name blog -exec mv '{}' public/blog/ \;
@@ -55,6 +55,6 @@ jobs:
     - name: After deployment scripts
       run: |
         # Refresh sitemap in Google and Bing
-        curl "https://www.google.com/webmasters/sitemaps/ping?sitemap=https://blog.flotiq.com/sitemap/sitemap-index.xml"
-        curl "https://www.bing.com/webmaster/ping.aspx?siteMap=https://blog.flotiq.com/sitemap/sitemap-index.xml"
+        curl "https://www.google.com/webmasters/sitemaps/ping?sitemap=https://flotiq.com/blog/sitemap/sitemap-index.xml"
+        curl "https://www.bing.com/webmaster/ping.aspx?siteMap=https://flotiq.com/blog/sitemap/sitemap-index.xml"
     

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Flotiq Blog
 
 This is a [Gatsby](https://gatsbyjs.org) starter project for a blog with tags and authors. It's configured to pull recipe data from [Flotiq](https://flotiq.com) and can be easily deployed to your cloud hosting - Heroku, Netlify, Gatsby Cloud, etc.
 
-See it live on [Flotiq/Blog](https://blog.flotiq.com/)
+See it live on [Flotiq/Blog](https://flotiq.com/blog)
 
 Screenshot
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,13 +4,13 @@ require('dotenv').config({
 });
 
 module.exports = {
-    pathPrefix: '',
+    pathPrefix: '/blog',
     siteMetadata: {
         title: 'Flotiq',
         description: 'Effortless headless CMS',
-        siteUrl: 'https://blog.flotiq.com', // full path to blog - no ending slash
+        siteUrl: 'https://flotiq.com', // full path to blog - no ending slash
         apiKey: process.env.SCOPED_FLOTIQ_API_KEY,
-        pathPrefix: '',
+        pathPrefix: '/blog',
 
     },
     plugins: [
@@ -70,8 +70,8 @@ module.exports = {
         {
             resolve: 'gatsby-plugin-robots-txt',
             options: {
-                host: 'https://blog.flotiq.com',
-                sitemap: 'https://blog.flotiq.com/sitemap.xml',
+                host: 'https://flotiq.com',
+                sitemap: 'https://flotiq.com/blog/sitemap.xml',
                 policy: [{ userAgent: '*', allow: '/' }],
             },
         },

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,13 +1,13 @@
 name = "flotiq-blog"
 main = "worker-index.js"
-compatibility_date = "2024-01-09"
+compatibility_date = "2024-12-05"
 
 [site]
 bucket = "./public"
 
 [env.production]
 name = "flotiq-blog-production"
-
-[env.staging]
-name = "flotiq-blog-staging"
-route = { pattern = "flotiq.com/staging-blog", zone_name = "flotiq.com", custom_domain = false }
+routes = [
+    { pattern = "flotiq.com/blog", zone_name = "flotiq.com", custom_domain = false},
+    { pattern = "flotiq.com/blog/*", zone_name = "flotiq.com", custom_domain = false}
+]


### PR DESCRIPTION
This PR includes changes required to move the blog to https://flotiq.com/blog URL:

- added pathPrefix from Gatsby config
- added --prefix-paths option from gatsby build command in ci.yml
- changed every occurence of blog.flotiq.com to flotiq.com/blog